### PR TITLE
Update HOL step-by-step - Cloud-native applications - Developer editi…

### DIFF
--- a/Hands-on lab/HOL step-by-step - Cloud-native applications - Developer edition.md
+++ b/Hands-on lab/HOL step-by-step - Cloud-native applications - Developer edition.md
@@ -1298,7 +1298,7 @@ In this task, deploy the web service using `kubectl`.
    > **Note**: Be sure to copy and paste only the contents of the code block carefully to avoid introducing any special characters.
 
    ```yaml
-   apiVersion: extensions/v1beta1
+   apiVersion: apps/v1
    kind: Deployment
    metadata:
      labels:


### PR DESCRIPTION
…on.md

`apiVersion: extensions/v1beta1` is not supported since Kubernetes 1.15 anymore. Considering that 1.17.9 is used (now), we should replace this to `apiVersion: apps/v1` instead