### PR TITLE
update k8s version to 1.17.16

### DIFF
--- a/Hands-on lab/arm/azuredeploy.json
+++ b/Hands-on lab/arm/azuredeploy.json
@@ -102,7 +102,7 @@
         "registrySku": "Standard",
         "registryAdminUserEnabled": true,
         "kubernetesClusterName": "[concat('fabmedical-', parameters('Suffix'))]",
-        "kubernetesVersion": "1.17.11",
+        "kubernetesVersion": "1.17.16",
         "kubernetesDnsPrefix": "[concat('fabmedical-', parameters('Suffix'), '-dns')]",
         "kubernetesAgentOsType": "Linux",
         "kubernetesAgentOsDiskSizeGB": 0,


### PR DESCRIPTION
This moves it up to the latest 1.17.x release that is supported by AKS and still supports the K8s dashboard.

This is related to Issue #218 