### PR TITLE
Fixing containerRegistry reference in Exercise 4 Task 3

### DIFF
--- a/Hands-on lab/HOL step-by-step - Cloud-native applications.md
+++ b/Hands-on lab/HOL step-by-step - Cloud-native applications.md
@@ -968,7 +968,7 @@ In this task, you will edit the web application source code to add Application I
               web.deployment.yml
               web.service.yml
             images: |
-              ${{ env.containerRegistry }}.azurecr.io/${{ env.imageRepository }}:${{ env.tag }}
+              ${{ env.containerRegistry }}/${{ env.imageRepository }}:${{ env.tag }}
             imagepullsecrets: |
               ingress-demo-secret
             namespace: ingress-demo


### PR DESCRIPTION
The `containerRegistry` variable already has the domain in it.  We can remove it from the code in the exercise.

Addresses #284 