### PR TITLE
Changes to resolve #303, #304, #305, and #307

### DIFF
--- a/Hands-on lab/Before the HOL - Cloud-native applications.md
+++ b/Hands-on lab/Before the HOL - Cloud-native applications.md
@@ -149,6 +149,8 @@ FabMedical has provided starter files for you. They have taken a copy of the web
 
 1. A GitHub personal access token (PAT) with appropriate permissions is required to set up and complete this lab - [Follow this link](https://github.com/settings/tokens/new?scopes=repo&description=GitHub%20Secrets%20CLI) to quickly set up a GitHub personal access token with the required permissions. Save the obtained PAT as it will be needed by future steps.
 
+> Note: Make sure to also select the `workflow` and `admin:org read:org` permission scopes in addition to the `repo` scopes already selected when visiting the aforementioned link.
+
 2. Set the following environment variables in an Azure Cloud Shell terminal.
 
    ```bash

--- a/Hands-on lab/Before the HOL - Cloud-native applications.md
+++ b/Hands-on lab/Before the HOL - Cloud-native applications.md
@@ -149,7 +149,7 @@ FabMedical has provided starter files for you. They have taken a copy of the web
 
 1. A GitHub personal access token (PAT) with appropriate permissions is required to set up and complete this lab - [Follow this link](https://github.com/settings/tokens/new?scopes=repo&description=GitHub%20Secrets%20CLI) to quickly set up a GitHub personal access token with the required permissions. Save the obtained PAT as it will be needed by future steps.
 
-> Note: Make sure to also select the `workflow` and `admin:org read:org` permission scopes in addition to the `repo` scopes already selected when visiting the aforementioned link.
+> **Note**: Make sure to also select the `workflow` and `admin:org read:org` permission scopes in addition to the `repo` scopes already selected when visiting the aforementioned link.
 
 2. Set the following environment variables in an Azure Cloud Shell terminal.
 

--- a/Hands-on lab/Before the HOL - Cloud-native applications.md
+++ b/Hands-on lab/Before the HOL - Cloud-native applications.md
@@ -149,7 +149,7 @@ FabMedical has provided starter files for you. They have taken a copy of the web
 
 1. A GitHub personal access token (PAT) with appropriate permissions is required to set up and complete this lab - [Follow this link](https://github.com/settings/tokens/new?scopes=repo&description=GitHub%20Secrets%20CLI) to quickly set up a GitHub personal access token with the required permissions. Save the obtained PAT as it will be needed by future steps.
 
-> **Note**: Make sure to also select the `workflow` and `admin:org read:org` permission scopes in addition to the `repo` scopes already selected when visiting the aforementioned link.
+> **Note**: Make sure to select the `workflow` and `admin:org read:org` permission scopes in addition to the `repo` scopes already selected when visiting the aforementioned link.
 
 2. Set the following environment variables in an Azure Cloud Shell terminal.
 

--- a/Hands-on lab/arm/azuredeploy.json
+++ b/Hands-on lab/arm/azuredeploy.json
@@ -102,7 +102,7 @@
         "registrySku": "Standard",
         "registryAdminUserEnabled": true,
         "kubernetesClusterName": "[concat('fabmedical-', parameters('Suffix'))]",
-        "kubernetesVersion": "1.21.2",
+        "kubernetesVersion": "1.21.9",
         "kubernetesDnsPrefix": "[concat('fabmedical-', parameters('Suffix'), '-dns')]",
         "kubernetesAgentOsType": "Linux",
         "kubernetesAgentOsDiskSizeGB": 0,

--- a/Hands-on lab/lab-files/developer/content-api/Dockerfile
+++ b/Hands-on lab/lab-files/developer/content-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS base
+FROM node:16.5.0-alpine AS base
 RUN apk -U add curl
 WORKDIR /usr/src/app
 EXPOSE 3001

--- a/Hands-on lab/lab-files/developer/content-init/Dockerfile
+++ b/Hands-on lab/lab-files/developer/content-init/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS base
+FROM node:16.5.0-alpine AS base
 WORKDIR /usr/src/app
 
 FROM node:argon AS build

--- a/Hands-on lab/lab-files/developer/scripts/create_azure_resources.sh
+++ b/Hands-on lab/lab-files/developer/scripts/create_azure_resources.sh
@@ -24,7 +24,7 @@ if [[ -z "${MCW_GITHUB_TOKEN}" ]]; then
 fi
 
 if [[ -z "${MCW_GITHUB_URL}" ]]; then
-    MCW_GITHUB_URL=https://$MCW_GITHUB_USERNAME:$MCW_GITHUB_TOKEN@github.com/$MCW_GITHUB_USERNAME/Fabmedical.git
+    MCW_GITHUB_URL=https://$MCW_GITHUB_TOKEN@github.com/$MCW_GITHUB_USERNAME/Fabmedical.git
 fi
 
 if [[ -z "${MCW_PRIMARY_LOCATION}" ]]; then


### PR DESCRIPTION
Resolves:

- The node:alpine image causing a failed execution for content-api in #303 
- The change of the AKS k8s version to 1.21.9 in the azuredeploy.json ARM template
- Refactoring the Github URL constructed in create_azure_resources.sh to include the Github token only in the base path URI
- Added verbiage to indicate the need to add additional permission scopes to the personal access token (Github token) created in Task 4, Step 1 of the Before HOL document