### PR TITLE
Fixing typo for content-web.yml in HOL #319

### DIFF
--- a/Hands-on lab/HOL step-by-step - Cloud-native applications.md
+++ b/Hands-on lab/HOL step-by-step - Cloud-native applications.md
@@ -1039,7 +1039,7 @@ This task will edit the web application source code to add Application Insights 
         branches:
         - main
         paths:
-        - 'content-api/**'
+        - 'content-web/**'
         - web.deployment.yml  # These two file
         - web.service.yml     # entries here
     ```


### PR DESCRIPTION
Fixing the typo reported in #319 

I did confirm under `Hands-on lab\lab-files\developer\.github\workflows\content-web.yml` that the paths are correct in the yaml file. No change needed there.